### PR TITLE
feat(recipe): 레시피 생성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### 추가 파일
+src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/ucaeon/yumbook/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/common/dto/ApiResponseDto.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.global.common.dto;
+
+public class ApiResponseDto {
+}

--- a/src/main/java/com/ucaeon/yumbook/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/common/dto/ApiResponseDto.java
@@ -1,4 +1,23 @@
-package com.ucaeon.yumbook.global.common.dto;
+package com.ucaeon.yumbook.common.dto;
 
-public class ApiResponseDto {
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponseDto<T> {
+    private final int status;
+    private final String code; // 성공 시에는 보통 "SUCCESS" 같은 문자열을 넣거나 null로 둡니다.
+    private final String message;
+    private final T data;
+
+    public ApiResponseDto(HttpStatus status, String code, String message, T data) {
+        this.status = status.value();
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponseDto<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponseDto<>(status, "SUCCESS", message, data);
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.controller;
+
+public class RecipeController {
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -1,4 +1,35 @@
 package com.ucaeon.yumbook.recipe.controller;
 
+import com.ucaeon.yumbook.common.dto.ApiResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeCreateResponseDto;
+import com.ucaeon.yumbook.recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recipes")
 public class RecipeController {
+
+    private final RecipeService recipeService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<RecipeCreateResponseDto>> createRecipe(@RequestBody RecipeCreateRequestDto requestDto) {
+        Long recipeId = recipeService.createRecipe(requestDto);
+        RecipeCreateResponseDto responseData = new RecipeCreateResponseDto(recipeId);
+
+        ApiResponseDto<RecipeCreateResponseDto> responseBody = ApiResponseDto.success(
+                HttpStatus.CREATED,
+                "레시피 생성에 성공했습니다.",
+                responseData
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
@@ -1,4 +1,33 @@
 package com.ucaeon.yumbook.recipe.domain;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recipe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String ingredients;
+
+    @Column(nullable = false)
+    private String instructions;
+
+    @Builder
+    private Recipe(String title, String ingredients, String instructions) {
+        this.title = title;
+        this.ingredients = ingredients;
+        this.instructions = instructions;
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.domain;
+
+public class Recipe {
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
@@ -1,4 +1,22 @@
 package com.ucaeon.yumbook.recipe.dto;
 
+import com.ucaeon.yumbook.recipe.domain.Recipe;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class RecipeCreateRequestDto {
+
+    private String title;
+    private String ingredients;
+    private String instructions;
+
+    public Recipe toEntity() {
+        return Recipe.builder()
+                .title(title)
+                .ingredients(ingredients)
+                .instructions(instructions)
+                .build();
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+public class RecipeCreateRequestDto {
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateResponseDto.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+public class RecipeCreateResponseDto {
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateResponseDto.java
@@ -1,4 +1,13 @@
 package com.ucaeon.yumbook.recipe.dto;
 
+import lombok.Getter;
+
+@Getter
 public class RecipeCreateResponseDto {
+    private final Long id;
+
+    public RecipeCreateResponseDto(Long id) {
+        this.id = id;
+    }
 }
+

--- a/src/main/java/com/ucaeon/yumbook/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/repository/RecipeRepository.java
@@ -1,4 +1,7 @@
 package com.ucaeon.yumbook.recipe.repository;
 
-public class RecipeRepository {
+import com.ucaeon.yumbook.recipe.domain.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/repository/RecipeRepository.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.repository;
+
+public class RecipeRepository {
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -1,4 +1,22 @@
 package com.ucaeon.yumbook.recipe.service;
 
+import com.ucaeon.yumbook.recipe.domain.Recipe;
+import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
+import com.ucaeon.yumbook.recipe.repository.RecipeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class RecipeService {
+
+    private final RecipeRepository recipeRepository;
+
+    @Transactional
+    public Long createRecipe(RecipeCreateRequestDto requestDto) {
+        Recipe recipe = requestDto.toEntity();
+        Recipe savedRecipe = recipeRepository.save(recipe);
+        return savedRecipe.getId();
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -1,0 +1,4 @@
+package com.ucaeon.yumbook.recipe.service;
+
+public class RecipeService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=yumbook


### PR DESCRIPTION
### 📝 작업 내용
레시피 정보를 받아 데이터베이스에 저장하는 기능을 구현했습니다.

### ✅ 작업 내역
- `Recipe` Entity 설계
- `RecipeCreateRequestDto` 생성 및 유효성 검증 추가
- `RecipeRepository` 인터페이스 작성
- `RecipeService`에 생성 로직 구현
- `RecipeController`에 생성 API 엔드포인트 추가
- `application.properties`를 `.gitignore`에 추가하고 추적 해제

### 🔍 기타 참고 사항
- H2 데이터베이스 연동 확인 완료
- Postman으로 레시피 생성 API 정상 동작 확인

### 🔗 관련 이슈
- Closes #3 