### PR TITLE
feat(recipe): 레시피 목록 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ out/
 /nbbuild/
 /dist/
 /nbdist/
+
 /.nb-gradle/
 
 ### VS Code ###

--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -1,16 +1,19 @@
 package com.ucaeon.yumbook.recipe.controller;
 
-import com.ucaeon.yumbook.common.dto.ApiResponseDto;
-import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
-import com.ucaeon.yumbook.recipe.dto.RecipeCreateResponseDto;
-import com.ucaeon.yumbook.recipe.service.RecipeService;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.ucaeon.yumbook.common.dto.ApiResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeCreateResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
+import com.ucaeon.yumbook.recipe.service.RecipeService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,7 +32,18 @@ public class RecipeController {
                 "레시피 생성에 성공했습니다.",
                 responseData
         );
-
         return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<List<RecipeListResponseDto>>> getAllRecipes() {
+        List<RecipeListResponseDto> recipes = recipeService.getAllRecipes();
+        
+        ApiResponseDto<List<RecipeListResponseDto>> responseBody = ApiResponseDto.success(
+                HttpStatus.OK,
+                "레시피 목록 조회에 성공했습니다.",
+                recipes
+        );
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeListResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeListResponseDto.java
@@ -1,0 +1,20 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+import com.ucaeon.yumbook.recipe.domain.Recipe;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeListResponseDto {
+    private final Long id;
+    private final String title;
+    private final String ingredients;
+    private final String instructions;
+
+    public RecipeListResponseDto(Recipe recipe) {
+        this.id = recipe.getId();
+        this.title = recipe.getTitle();
+        this.ingredients = recipe.getIngredients();
+        this.instructions = recipe.getInstructions();
+    }
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -1,11 +1,16 @@
 package com.ucaeon.yumbook.recipe.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.ucaeon.yumbook.recipe.domain.Recipe;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
 import com.ucaeon.yumbook.recipe.repository.RecipeRepository;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +23,12 @@ public class RecipeService {
         Recipe recipe = requestDto.toEntity();
         Recipe savedRecipe = recipeRepository.save(recipe);
         return savedRecipe.getId();
+    }
+
+    public List<RecipeListResponseDto> getAllRecipes() {
+        List<Recipe> recipes = recipeRepository.findAll();
+        return recipes.stream()
+                .map(RecipeListResponseDto::new)
+                .toList();
     }
 }

--- a/tatus
+++ b/tatus
@@ -1,0 +1,6 @@
+  feature/1-exception-handling[m
+* [32mfeature/3-create-recipe[m
+  main[m
+  [31mremotes/origin/feature/1-exception-handling[m
+  [31mremotes/origin/feature/3-create-recipe[m
+  [31mremotes/origin/main[m


### PR DESCRIPTION
### 🥅 구현 목표
- `GET /api/recipes` 엔드포인트 구현
- 레시피 목록을 JSON 형태로 반환
- 표준화된 API 응답 형식 사용

### 기능 구현
- [x] RecipeListResponseDto 생성
- [x] RecipeService에 getAllRecipes() 메서드 추가
- [x] RecipeController에 GET /api/recipes 엔드포인트 추가
- [x] Stream API를 사용한 엔티티-DTO 변환

### 🔧 수정된 파일
- [x] `RecipeService.java` - 목록 조회 비즈니스 로직 추가
- [x] `RecipeController.java` - 목록 조회 엔드포인트 추가

### 🔗 관련 이슈
- Closes #5