### PR TITLE
feat(recipe): 레시피 상세 조회 API 개발

### DIFF
--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ucaeon.yumbook.common.dto.ApiResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
 import com.ucaeon.yumbook.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,19 @@ public class RecipeController {
                 "레시피 목록 조회에 성공했습니다.",
                 recipes
         );
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<RecipeDetailResponseDto>> getRecipeById(@PathVariable Long id) {
+        RecipeDetailResponseDto recipe = recipeService.getRecipeById(id);
+        
+        ApiResponseDto<RecipeDetailResponseDto> responseBody = ApiResponseDto.success(
+                HttpStatus.OK,
+                "레시피 상세 조회에 성공했습니다.",
+                recipe
+        );
+        
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDetailResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDetailResponseDto.java
@@ -1,0 +1,19 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+import com.ucaeon.yumbook.recipe.domain.Recipe;
+import lombok.Getter;
+
+@Getter
+public class RecipeDetailResponseDto {
+    private final Long id;
+    private final String title;
+    private final String ingredients;
+    private final String instructions;
+
+    public RecipeDetailResponseDto(Recipe recipe) {
+        this.id = recipe.getId();
+        this.title = recipe.getTitle();
+        this.ingredients = recipe.getIngredients();
+        this.instructions = recipe.getInstructions();
+    }
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -4,8 +4,11 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.ucaeon.yumbook.global.exception.CustomException;
+import com.ucaeon.yumbook.global.exception.ErrorCode;
 import com.ucaeon.yumbook.recipe.domain.Recipe;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
 import com.ucaeon.yumbook.recipe.repository.RecipeRepository;
 
@@ -24,11 +27,18 @@ public class RecipeService {
         Recipe savedRecipe = recipeRepository.save(recipe);
         return savedRecipe.getId();
     }
+    
 
     public List<RecipeListResponseDto> getAllRecipes() {
         List<Recipe> recipes = recipeRepository.findAll();
         return recipes.stream()
                 .map(RecipeListResponseDto::new)
                 .toList();
+    }
+
+    public RecipeDetailResponseDto getRecipeById(Long id) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+        return new RecipeDetailResponseDto(recipe);
     }
 }

--- a/src/test/java/com/example/recipe_server/RecipeServerApplicationTests.java
+++ b/src/test/java/com/example/recipe_server/RecipeServerApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.recipe_server;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RecipeServerApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
## 🥅 구현 목표
- `GET /api/recipes/{id}` 엔드포인트 구현
- 특정 레시피의 상세 정보를 JSON 형태로 반환
- 레시피가 존재하지 않을 경우 404 에러 처리

## ✅ 구현된 기능
- [x] RecipeDetailResponseDto 생성
- [x] RecipeService에 getRecipeById() 메서드 추가
- [x] RecipeController에 GET /api/recipes/{id} 엔드포인트 추가
- [x] 레시피 존재 여부 검증 로직 추가
- [x] 표준화된 API 응답 형식 사용

## 🔗 관련 이슈
- Closes #6