### PR TITLE
feat(recipe): 레시피 수정 API 개발

### DIFF
--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +15,8 @@ import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeUpdateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeUpdateResponseDto;
 import com.ucaeon.yumbook.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +40,7 @@ public class RecipeController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
     }
 
+    
     @GetMapping
     public ResponseEntity<ApiResponseDto<List<RecipeListResponseDto>>> getAllRecipes() {
         List<RecipeListResponseDto> recipes = recipeService.getAllRecipes();
@@ -49,6 +53,7 @@ public class RecipeController {
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 
+
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseDto<RecipeDetailResponseDto>> getRecipeById(@PathVariable Long id) {
         RecipeDetailResponseDto recipe = recipeService.getRecipeById(id);
@@ -56,6 +61,21 @@ public class RecipeController {
         ApiResponseDto<RecipeDetailResponseDto> responseBody = ApiResponseDto.success(
                 HttpStatus.OK,
                 "레시피 상세 조회에 성공했습니다.",
+                recipe
+        );
+        
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<RecipeUpdateResponseDto>> updateRecipe(
+            @PathVariable Long id, 
+            @RequestBody RecipeUpdateRequestDto requestDto) {
+        RecipeUpdateResponseDto recipe = recipeService.updateRecipe(id, requestDto);
+        
+        ApiResponseDto<RecipeUpdateResponseDto> responseBody = ApiResponseDto.success(
+                HttpStatus.OK,
+                "레시피 수정에 성공했습니다.",
                 recipe
         );
         

--- a/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
@@ -30,4 +30,10 @@ public class Recipe {
         this.ingredients = ingredients;
         this.instructions = instructions;
     }
+
+    public void update(String title, String ingredients, String instructions) {
+        this.title = title;
+        this.ingredients = ingredients;
+        this.instructions = instructions;
+    }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateRequestDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecipeUpdateRequestDto {
+    private String title;
+    private String ingredients;
+    private String instructions;
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateResponseDto.java
@@ -1,0 +1,14 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeUpdateResponseDto {
+    private final Long id;
+    private final String title;
+
+    public RecipeUpdateResponseDto(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -10,6 +10,8 @@ import com.ucaeon.yumbook.recipe.domain.Recipe;
 import com.ucaeon.yumbook.recipe.dto.RecipeCreateRequestDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeUpdateRequestDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeUpdateResponseDto;
 import com.ucaeon.yumbook.recipe.repository.RecipeRepository;
 
 import jakarta.transaction.Transactional;
@@ -40,5 +42,16 @@ public class RecipeService {
         Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
         return new RecipeDetailResponseDto(recipe);
+    }
+    
+
+    @Transactional
+    public RecipeUpdateResponseDto updateRecipe(Long id, RecipeUpdateRequestDto requestDto) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+        
+        recipe.update(requestDto.getTitle(), requestDto.getIngredients(), requestDto.getInstructions());
+        
+        return new RecipeUpdateResponseDto(recipe.getId(), recipe.getTitle());
     }
 }


### PR DESCRIPTION
## 🥅 구현 목표
- `PUT /api/recipes/{id}` 엔드포인트 구현
- 기존 레시피 정보를 수정하고 결과를 반환
- 레시피가 존재하지 않을 경우 404 에러 처리

## ✅ 구현된 기능
- [x] RecipeUpdateRequestDto 생성
- [x] RecipeUpdateResponseDto 생성
- [x] Recipe 엔티티에 update() 메서드 추가
- [x] RecipeService에 updateRecipe() 메서드 추가
- [x] RecipeController에 PUT /api/recipes/{id} 엔드포인트 추가
- [x] 레시피 존재 여부 검증 로직 추가
- [x] 표준화된 API 응답 형식 사용

## 관련 이슈
- Closes #7