### PR TITLE
feat(recipe): 레시피 삭제 API 개발

### DIFF
--- a/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/controller/RecipeController.java
@@ -3,6 +3,7 @@ package com.ucaeon.yumbook.recipe.controller;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeUpdateRequestDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeUpdateResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeDeleteResponseDto;
 import com.ucaeon.yumbook.recipe.service.RecipeService;
 import lombok.RequiredArgsConstructor;
 
@@ -68,14 +70,25 @@ public class RecipeController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponseDto<RecipeUpdateResponseDto>> updateRecipe(
-            @PathVariable Long id, 
-            @RequestBody RecipeUpdateRequestDto requestDto) {
+    public ResponseEntity<ApiResponseDto<RecipeUpdateResponseDto>> updateRecipe( @PathVariable Long id, @RequestBody RecipeUpdateRequestDto requestDto) {
         RecipeUpdateResponseDto recipe = recipeService.updateRecipe(id, requestDto);
         
         ApiResponseDto<RecipeUpdateResponseDto> responseBody = ApiResponseDto.success(
                 HttpStatus.OK,
                 "레시피 수정에 성공했습니다.",
+                recipe
+        );
+        
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponseDto<RecipeDeleteResponseDto>> deleteRecipe(@PathVariable Long id) {
+        RecipeDeleteResponseDto recipe = recipeService.deleteRecipe(id);
+        
+        ApiResponseDto<RecipeDeleteResponseDto> responseBody = ApiResponseDto.success(
+                HttpStatus.OK,
+                "레시피 삭제에 성공했습니다.",
                 recipe
         );
         

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDeleteResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDeleteResponseDto.java
@@ -1,0 +1,14 @@
+package com.ucaeon.yumbook.recipe.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeDeleteResponseDto {
+    private final Long id;
+    private final String title;
+
+    public RecipeDeleteResponseDto(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -12,6 +12,7 @@ import com.ucaeon.yumbook.recipe.dto.RecipeDetailResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeListResponseDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeUpdateRequestDto;
 import com.ucaeon.yumbook.recipe.dto.RecipeUpdateResponseDto;
+import com.ucaeon.yumbook.recipe.dto.RecipeDeleteResponseDto;
 import com.ucaeon.yumbook.recipe.repository.RecipeRepository;
 
 import jakarta.transaction.Transactional;
@@ -38,6 +39,7 @@ public class RecipeService {
                 .toList();
     }
 
+
     public RecipeDetailResponseDto getRecipeById(Long id) {
         Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
@@ -53,5 +55,15 @@ public class RecipeService {
         recipe.update(requestDto.getTitle(), requestDto.getIngredients(), requestDto.getInstructions());
         
         return new RecipeUpdateResponseDto(recipe.getId(), recipe.getTitle());
+    }
+
+    @Transactional
+    public RecipeDeleteResponseDto deleteRecipe(Long id) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
+        
+        recipeRepository.deleteById(id);
+        
+        return new RecipeDeleteResponseDto(recipe.getId(), recipe.getTitle());
     }
 }


### PR DESCRIPTION
## 🎯 구현 목표
- `DELETE /api/recipes/{id}` 엔드포인트 구현
- 특정 레시피 삭제 -> 결과를 반환
- 레시피가 존재하지 않을 경우 404 에러 처리

## ✅ 구현된 기능
- [x] RecipeDeleteResponseDto 생성
- [x] RecipeService에 deleteRecipe() 메서드 추가
- [x] RecipeController에 DELETE /api/recipes/{id} 엔드포인트 추가
- [x] 레시피 존재 여부 검증 로직 추가
- [x] 표준화된 API 응답 형식 사용

## 🔗 관련 이슈
- Closes #8