### PR TITLE
feat: 레시피 태그 기능 추가

### DIFF
--- a/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/domain/Recipe.java
@@ -1,6 +1,10 @@
 package com.ucaeon.yumbook.recipe.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,16 +28,28 @@ public class Recipe {
     @Column(nullable = false)
     private String instructions;
 
+    private String difficulty;
+
+    private String cookingTime;
+
+    private String servings;
+
     @Builder
-    private Recipe(String title, String ingredients, String instructions) {
+    private Recipe(String title, String ingredients, String instructions, String difficulty, String cookingTime, String servings) {
         this.title = title;
         this.ingredients = ingredients;
         this.instructions = instructions;
+        this.difficulty = difficulty;
+        this.cookingTime = cookingTime;
+        this.servings = servings;
     }
 
-    public void update(String title, String ingredients, String instructions) {
+    public void update(String title, String ingredients, String instructions, String difficulty, String cookingTime, String servings) {
         this.title = title;
         this.ingredients = ingredients;
         this.instructions = instructions;
+        this.difficulty = difficulty;
+        this.cookingTime = cookingTime;
+        this.servings = servings;
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeCreateRequestDto.java
@@ -22,11 +22,20 @@ public class RecipeCreateRequestDto {
     @Size(max = 2000, message = "조리법은 2000자 이하로 입력해주세요")
     private String instructions;
 
+    private String difficulty;
+
+    private String cookingTime;
+
+    private String servings;
+
     public Recipe toEntity() {
         return Recipe.builder()
                 .title(title)
                 .ingredients(ingredients)
                 .instructions(instructions)
+                .difficulty(difficulty)
+                .cookingTime(cookingTime)
+                .servings(servings)
                 .build();
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDetailResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeDetailResponseDto.java
@@ -9,11 +9,17 @@ public class RecipeDetailResponseDto {
     private final String title;
     private final String ingredients;
     private final String instructions;
+    private final String difficulty;
+    private final String cookingTime;
+    private final String servings;
 
     public RecipeDetailResponseDto(Recipe recipe) {
         this.id = recipe.getId();
         this.title = recipe.getTitle();
         this.ingredients = recipe.getIngredients();
         this.instructions = recipe.getInstructions();
+        this.difficulty = recipe.getDifficulty();
+        this.cookingTime = recipe.getCookingTime();
+        this.servings = recipe.getServings();
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeListResponseDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeListResponseDto.java
@@ -10,11 +10,17 @@ public class RecipeListResponseDto {
     private final String title;
     private final String ingredients;
     private final String instructions;
+    private final String difficulty;
+    private final String cookingTime;
+    private final String servings;
 
     public RecipeListResponseDto(Recipe recipe) {
         this.id = recipe.getId();
         this.title = recipe.getTitle();
         this.ingredients = recipe.getIngredients();
         this.instructions = recipe.getInstructions();
+        this.difficulty = recipe.getDifficulty();
+        this.cookingTime = recipe.getCookingTime();
+        this.servings = recipe.getServings();
     }
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateRequestDto.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/dto/RecipeUpdateRequestDto.java
@@ -19,4 +19,10 @@ public class RecipeUpdateRequestDto {
     @NotBlank(message = "조리법은 필수입니다")
     @Size(max = 2000, message = "조리법은 2000자 이하로 입력해주세요")
     private String instructions;
+
+    private String difficulty;
+
+    private String cookingTime;
+
+    private String servings;
 }

--- a/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
+++ b/src/main/java/com/ucaeon/yumbook/recipe/service/RecipeService.java
@@ -52,11 +52,13 @@ public class RecipeService {
         Recipe recipe = recipeRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
         
-        recipe.update(requestDto.getTitle(), requestDto.getIngredients(), requestDto.getInstructions());
+        recipe.update(requestDto.getTitle(), requestDto.getIngredients(), requestDto.getInstructions(), 
+                     requestDto.getDifficulty(), requestDto.getCookingTime(), requestDto.getServings());
         
         return new RecipeUpdateResponseDto(recipe.getId(), recipe.getTitle());
     }
 
+    
     @Transactional
     public RecipeDeleteResponseDto deleteRecipe(Long id) {
         Recipe recipe = recipeRepository.findById(id)


### PR DESCRIPTION
## 구현 목표
난이도, 조리시간, 인분을 태그로 표시할 수 있도록 백엔드 필드 추가

## ✅ 구현된 기능
- Recipe 엔티티에 3개 태그 필드 추가
- difficulty (난이도): "쉬움", "보통", "어려움"
- cookingTime (조리시간): 자유 입력
- servings (인분): "1인분", "2인분", "3인분", "4인분", "5인분", "5+인분"

🔗 관련 이슈
- Closes #15 